### PR TITLE
Fix node.active for certain cases

### DIFF
--- a/src/elements/Node.php
+++ b/src/elements/Node.php
@@ -1006,8 +1006,9 @@ class Node extends Element
             $nodeUrl = UrlHelper::siteUrl($nodeUrl);
         }
 
-        // Trim the node's url to normalise for comparison, after we've resolved it to an absolute URL.
+        // Trim the current and node's url to normalise for comparison, after we've resolved it to an absolute URL.
         $nodeUrl = trim($nodeUrl, '/');
+        $currentUrl = trim($currentUrl, '/');
 
         // Stop straight away if this is the homepage entry
         if ($this->_elementUrl === '__home__') {


### PR DESCRIPTION
I would like to include this, we run into the problem that there is no node.active when query strings are used on the homepage. This because the trailing slash is stripped from the nodeUrl but not from the currentUrl after removing the query parameters.